### PR TITLE
Add expansion resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,6 @@ Looking to help the world's leading brands and the next generation of successful
 * [Multi-Storefront Overview](https://support.bigcommerce.com/s/article/Multi-Storefront)
 * [Subscription Foundation README](https://github.com/bigcommerce/subscription-foundation/blob/main/README.md)
 * [Subscription Foundation Overview](https://developer.bigcommerce.com/api-docs/partner/subscription-solutions/foundation-guide)
-* [Channels API Reference](/api-reference/store-management/channels/channels/createchannel)
+* [Channels API Reference](https://developer.bigcommerce.com/api-reference/store-management/channels/channels/createchannel)
 * [App API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts)
 * [Guide to Building Apps](/api-docs/apps/guide/intro)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Looking to help the world's leading brands and the next generation of successful
 ### Expansion resources
 * [Multi-Storefront Overview](https://support.bigcommerce.com/s/article/Multi-Storefront)
 * [Subscription Foundation README](https://github.com/bigcommerce/subscription-foundation/blob/main/README.md)
-* [Subscription Foundation Overview](/api-docs/partner/subscription-solutions/foundation-guide)
+* [Subscription Foundation Overview](https://developer.bigcommerce.com/api-docs/partner/subscription-solutions/foundation-guide)
 * [Channels API Reference](/api-reference/store-management/channels/channels/createchannel)
 * [App API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts)
 * [Guide to Building Apps](/api-docs/apps/guide/intro)

--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ Looking to help the world's leading brands and the next generation of successful
 * [Subscription Foundation Overview](https://developer.bigcommerce.com/api-docs/partner/subscription-solutions/foundation-guide)
 * [Channels API Reference](https://developer.bigcommerce.com/api-reference/store-management/channels/channels/createchannel)
 * [App API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts)
-* [Guide to Building Apps](/api-docs/apps/guide/intro)
+* [Guide to Building Apps](https://developer.bigcommerce.com/api-docs/apps/guide/intro)

--- a/README.md
+++ b/README.md
@@ -107,5 +107,5 @@ Looking to help the world's leading brands and the next generation of successful
 * [Subscription Foundation README](https://github.com/bigcommerce/subscription-foundation/blob/main/README.md)
 * [Subscription Foundation Overview](https://developer.bigcommerce.com/api-docs/partner/subscription-solutions/foundation-guide)
 * [Channels API Reference](https://developer.bigcommerce.com/api-reference/store-management/channels/channels/createchannel)
-* [App API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts)
+* [App API Accounts](https://developer.bigcommerce.com/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts)
 * [Guide to Building Apps](https://developer.bigcommerce.com/api-docs/apps/guide/intro)

--- a/README.md
+++ b/README.md
@@ -101,3 +101,11 @@ Looking to help the world's leading brands and the next generation of successful
 - [BigCommerce Dev Center](https://developer.bigcommerce.com/?source=pos-foundation) - Learn more about BigCommerce platform features, APIs and SDKs
 - [BigDesign](https://developer.bigcommerce.com/big-design/?source=pos-foundation) - BigCommerce's library of React components with sandbox tools
 - [Building BigCommerce Apps](https://developer.bigcommerce.com/api-docs/apps/guide/intro?source=pos-foundation) - Learn more about apps, from lightweight single-merchant customizations to fully-featured apps you can sell in the BigCommerce App Marketplace
+
+### Expansion resources
+* [Multi-Storefront Overview](https://support.bigcommerce.com/s/article/Multi-Storefront)
+* [Subscription Foundation README](https://github.com/bigcommerce/subscription-foundation/blob/main/README.md)
+* [Subscription Foundation Overview](/api-docs/partner/subscription-solutions/foundation-guide)
+* [Channels API Reference](/api-reference/store-management/channels/channels/createchannel)
+* [App API Accounts](/api-docs/getting-started/authentication/rest-api-authentication#app-api-accounts)
+* [Guide to Building Apps](/api-docs/apps/guide/intro)


### PR DESCRIPTION
This section was removed from the POS Foundation Guide. We want to add it to the readme instead.
https://developer.bigcommerce.com/docs/495a2058c70b4-pos-foundation